### PR TITLE
VPC support for lambda

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -3,7 +3,7 @@ resource "aws_iam_role_policy_attachment" "vpc_permissions" {
   roles      = ["${aws_iam_role.iam_for_lambda.name}"]
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 
-  count      = "${length(var.subnet_ids)} != 0 ? 1 : 0"
+  count      = "${length(var.subnet_ids) != 0 ? 1 : 0}"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {

--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,11 @@
+resource "aws_iam_role_policy_attachment" "vpc_permissions" {
+  name       = "${var.function_name}-vpc_permissions"
+  roles      = ["${aws_iam_role.iam_for_lambda.name}"]
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+
+  count      = "${length(var.subnet_ids)} != 0 ? 1 : 0"
+}
+
 resource "aws_iam_role" "iam_for_lambda" {
   assume_role_policy = <<EOF
 {

--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,5 @@
 resource "aws_iam_role_policy_attachment" "vpc_permissions" {
-  name       = "${var.function_name}-vpc_permissions"
-  roles      = ["${aws_iam_role.iam_for_lambda.name}"]
+  role       = "${aws_iam_role.iam_for_lambda.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 
   count      = "${length(var.subnet_ids) != 0 ? 1 : 0}"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "lambda_function" {
 
   vpc_config {
     subnet_ids         = "${var.subnet_ids}"
-    security_group_ids = "${list(var.security_group_ids)}"
+    security_group_ids = "${var.security_group_ids}"
   }
 
   environment {

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,11 @@ resource "aws_lambda_function" "lambda_function" {
   runtime       = "${var.runtime}"
   timeout       = "${var.timeout}"
 
+  vpc_config {
+    subnet_ids         = "${var.subnet_ids}"
+    security_group_ids = "${var.security_group_ids}"
+  }
+
   environment {
     variables = "${var.lambda_env}"
   }

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,8 @@ resource "aws_lambda_function" "lambda_function" {
   timeout       = "${var.timeout}"
 
   vpc_config {
-    subnet_ids         = "${list(var.subnet_ids)}"
-    security_group_ids = "${list(var.security_group_ids)}"
+    subnet_ids         = "${var.subnet_ids}"
+    security_group_ids = "${var.security_group_ids}"
   }
 
   environment {

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "lambda_function" {
 
   vpc_config {
     subnet_ids         = "${var.subnet_ids}"
-    security_group_ids = "${var.security_group_ids}"
+    security_group_ids = "${list(var.security_group_ids)}"
   }
 
   environment {

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "lambda_function" {
 
   vpc_config {
     subnet_ids         = "${var.subnet_ids}"
-    security_group_ids = "${var.security_group_ids}"
+    security_group_ids = ["${var.security_group_ids}"]
   }
 
   environment {

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,8 @@ resource "aws_lambda_function" "lambda_function" {
   timeout       = "${var.timeout}"
 
   vpc_config {
-    subnet_ids         = "${var.subnet_ids}"
-    security_group_ids = "${var.security_group_ids}"
+    subnet_ids         = "${list(var.subnet_ids)}"
+    security_group_ids = "${list(var.security_group_ids)}"
   }
 
   environment {

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -20,6 +20,20 @@ module "lambda" {
   lambda_env             = "${var.lambda_env}"
   lambda_iam_policy_name = "lambda-IAM-policy-name"
   lambda_cron_schedule   = "rate(5 minutes)"
+  subnet_ids             = "${var.subnet_ids}"
+  security_group_ids     = "${var.security_group_ids}"
+}
+
+variable "subnet_ids" {
+  type        = "list"
+  description = "The VPC subnets in which the lambda runs"
+  default     = []
+}
+
+variable "security_group_ids" {
+  type        = "list"
+  description = "The VPC security groups assigned to the lambda"
+  default     = []
 }
 
 variable "lambda_env" {

--- a/test/test_lambda.py
+++ b/test/test_lambda.py
@@ -31,22 +31,76 @@ class TestCreateTaskdef(unittest.TestCase):
         ]).decode('utf-8')
         assert dedent("""
             + module.lambda.aws_lambda_function.lambda_function
-                arn:              "<computed>"
-                environment.#:    "1"
-                function_name:    "check_lambda_function"
-                handler:          "some_handler"
-                invoke_arn:       "<computed>"
-                last_modified:    "<computed>"
-                memory_size:      "128"
-                publish:          "false"
-                qualified_arn:    "<computed>"
-                role:             "${aws_iam_role.iam_for_lambda.arn}"
-                runtime:          "python"
-                s3_bucket:        "cdflow-lambda-releases"
-                s3_key:           "s3key.zip"
-                source_code_hash: "<computed>"
-                timeout:          "3"
-                version:          "<computed>"
+                arn:                 "<computed>"
+                environment.#:       "1"
+                function_name:       "check_lambda_function"
+                handler:             "some_handler"
+                invoke_arn:          "<computed>"
+                last_modified:       "<computed>"
+                memory_size:         "128"
+                publish:             "false"
+                qualified_arn:       "<computed>"
+                role:                "${aws_iam_role.iam_for_lambda.arn}"
+                runtime:             "python"
+                s3_bucket:           "cdflow-lambda-releases"
+                s3_key:              "s3key.zip"
+                source_code_hash:    "<computed>"
+                timeout:             "3"
+                version:             "<computed>"
+                vpc_config.#:        "1"
+                vpc_config.0.vpc_id: "<computed>"
+        """).strip() in output
+
+    def test_create_lambda_in_vpc(self):
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'subnet_ids=[1,2,3]',
+            '-var', 'security_group_ids=[4]',
+            '-no-color',
+            'test/infra'
+        ]).decode('utf-8')
+        assert dedent("""
+             + module.lambda.aws_lambda_function.lambda_function
+                 arn:                                        "<computed>"
+                 environment.#:                              "1"
+                 function_name:                              "check_lambda_function"
+                 handler:                                    "some_handler"
+                 invoke_arn:                                 "<computed>"
+                 last_modified:                              "<computed>"
+                 memory_size:                                "128"
+                 publish:                                    "false"
+                 qualified_arn:                              "<computed>"
+                 role:                                       "${aws_iam_role.iam_for_lambda.arn}"
+                 runtime:                                    "python"
+                 s3_bucket:                                  "cdflow-lambda-releases"
+                 s3_key:                                     "s3key.zip"
+                 source_code_hash:                           "<computed>"
+                 timeout:                                    "3"
+                 version:                                    "<computed>"
+                 vpc_config.#:                               "1"
+                 vpc_config.0.security_group_ids.#:          "1"
+                 vpc_config.0.security_group_ids.4088798008: "4"
+                 vpc_config.0.subnet_ids.#:                  "3"
+                 vpc_config.0.subnet_ids.1842515611:         "3"
+                 vpc_config.0.subnet_ids.2212294583:         "1"
+                 vpc_config.0.subnet_ids.450215437:          "2"
+                 vpc_config.0.vpc_id:                        "<computed>"
+        """).strip() in output
+
+    def test_lambda_in_vpc_gets_correct_execution_role(self):
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'subnet_ids=[1,2,3]',
+            '-var', 'security_group_ids=[4]',
+            '-no-color',
+            'test/infra'
+        ]).decode('utf-8')
+        assert dedent("""
+            + module.lambda.aws_iam_role_policy_attachment.vpc_permissions
+                policy_arn: "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+                role:       "${aws_iam_role.iam_for_lambda.name}"
         """).strip() in output
 
     def test_iam_policy_name_for_lambda_created(self):

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,15 @@ variable "lambda_iam_policy_name" {
 variable "lambda_cron_schedule" {
   description = "The sceduling expression for how often the lambda function runs."
 }
+
+variable "subnet_ids" {
+  type        = "list"
+  description = "The VPC subnets in which the lambda runs"
+  default     = []
+}
+
+variable "security_group_ids" {
+  type        = "list"
+  description = "The VPC security groups assigned to the lambda"
+  default     = []
+}


### PR DESCRIPTION
Allow the lambda to run inside a VPC.

Only tested with 0.9.4 which looks to be affected by this bug: https://github.com/hashicorp/terraform/issues/14108