### PR TITLE
Export IAM role name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ This module will deploy a lambda function and a cron rule to run the lambda func
 - `runtime` - (string) - **REQUIRED** The runtime environment for the Lambda function you are uploading.
 - `lambda_env` - (string) - Environment parameters passed to the lambda function
 - `lambda_iam_policy_name` (string) - **REQUIRED** - The name for the Lambda functions IAM policy
-- `lambda_cron_schedule` (string) - **REQUIRED** - The scheduling expression. For example, cron(0 20 * * ? *) or rate(5 minutes).
+- `lambda_cron_schedule` (string) - **REQUIRED** - The scheduling expression. For example, cron(0 20 \* \* ? \*) or rate(5 minutes).
+- `subnet_ids` (list) - _optional_ - The ids of VPC subnets to run in.
+- `security_group_ids` (list) - _optional_ - The ids of VPC security groups to assign to the lambda.
+- `timeout` (string) - _optional_ - The number of seconds the lambda will be allowed to run for.
 
 ## Usage
 
@@ -26,7 +29,6 @@ module "lambda-function" {
   handler                   = "do_foo_handler"
   runtime                   = "nodejs"
   lambda_env                = "${var.lambda_env}"
-  lambda_iam_policy_name    = "name for lambda iam policy"
   lambda_cron_schedule      = "rate(5 minutes)"
 }
 ```

--- a/iam.tf
+++ b/iam.tf
@@ -1,4 +1,5 @@
 resource "aws_iam_role" "iam_for_lambda" {
+  name_prefix        = "${var.function_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "iam_for_lambda" {
-  name_prefix        = "${var.function_name}"
+  name_prefix        = "${replace(replace(var.function_name, "/(.{0,32}).*/", "$1"), "/^-+|-+$/", "")}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "lambda_arn" {
   value = "${aws_lambda_function.lambda_function.arn}"
 }
+
+output "lambda_iam_role_arn" {
+  value = "${aws_iam_role.iam_for_lambda.arn}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,6 @@ output "lambda_arn" {
   value = "${aws_lambda_function.lambda_function.arn}"
 }
 
-output "lambda_iam_role_arn" {
-  value = "${aws_iam_role.iam_for_lambda.arn}"
+output "lambda_iam_role_name" {
+  value = "${aws_iam_role.iam_for_lambda.name}"
 }

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -18,7 +18,6 @@ module "lambda" {
   handler                = "some_handler"
   runtime                = "python"
   lambda_env             = "${var.lambda_env}"
-  lambda_iam_policy_name = "lambda-IAM-policy-name"
   lambda_cron_schedule   = "rate(5 minutes)"
 
   subnet_ids         = "${var.subnet_ids}"
@@ -33,7 +32,6 @@ module "lambda_long_name" {
   handler                = "some_handler"
   runtime                = "python"
   lambda_env             = "${var.lambda_env}"
-  lambda_iam_policy_name = "lambda-IAM-policy-name"
   lambda_cron_schedule   = "rate(5 minutes)"
 
   subnet_ids         = "${var.subnet_ids}"

--- a/variables.tf
+++ b/variables.tf
@@ -19,10 +19,6 @@ variable "runtime" {
   description = "The runtime environment for the Lambda function you are uploading."
 }
 
-variable "lambda_iam_policy_name" {
-  description = "The name for the Lambda functions IAM policy."
-}
-
 variable "lambda_cron_schedule" {
   description = "The sceduling expression for how often the lambda function runs."
 }
@@ -47,4 +43,9 @@ variable "lambda_env" {
   description = "Environment parameters passed to the lambda function."
   type        = "map"
   default     = {}
+}
+
+variable "lambda_iam_policy_name" {
+  description = "[DEPRECATED] The name for the Lambda functions IAM policy."
+  default     = ""
 }


### PR DESCRIPTION
The name of the IAM role attached to the lambda is required for assigning other permissions to the function.