### PR TITLE
Adds log subs for datadog logs kinesis stream

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,3 +37,12 @@ resource "aws_lambda_permission" "allow_cloudwatch" {
   principal     = "events.amazonaws.com"
   source_arn    = "${aws_cloudwatch_event_rule.cron_schedule.arn}"
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "kinesis_log_stream" {
+  count           = "${var.datadog_log_subscription_arn != "" ? 1 : 0}"
+  name            = "kinesis-log-stream-${var.function_name}"
+  destination_arn = "${var.datadog_log_subscription_arn}"
+  log_group_name  = "/aws/lambda/${var.function_name}"
+  filter_pattern  = ""
+  depends_on      = ["aws_lambda_function.lambda_function"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,11 @@ variable "security_group_ids" {
 }
 
 // Optional Variables
+variable "datadog_log_subscription_arn" {
+  description = "Log subscription arn for shipping logs to datadog"
+  default     = ""
+}
+
 variable "timeout" {
   description = "The maximum time in seconds that the Lambda can run for"
   default     = 3


### PR DESCRIPTION
This will mean that logs from created lambdas will be shipped to
datadog.

JIRA: PLAT-1755